### PR TITLE
Fix username env bug and env-variable injections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 asmfetch
 compile_commands.json
+.etc/

--- a/asmfetch.S
+++ b/asmfetch.S
@@ -33,7 +33,12 @@
 
 _start:
 	mov  rbp, rsp
-	add  rbp, 24
+	mov  r11, [rbp] # calculate env-var offset, makes finding faster and not broken when passing args!
+	mov  rax, 8
+	mul  r11
+	mov  r11, rax
+	add  r11, 16
+	add  rbp, r11
 	call parse_envs
 	call uname
 	call parse_release

--- a/env.S
+++ b/env.S
@@ -1,7 +1,8 @@
-env_username:   .ascii "USER"
-env_shell:      .ascii "SHELL"
-env_desktop:    .ascii "XDG_CURRENT_DESKTOP"
-env_session:    .ascii "XDG_SESSION_TYPE"
+env_username:      .ascii "USERNAME"
+env_username_alt:  .ascii "USER"
+env_shell:         .ascii "SHELL"
+env_desktop:       .ascii "XDG_CURRENT_DESKTOP"
+env_session:       .ascii "XDG_SESSION_TYPE"
 
 .lcomm username, 65
 .lcomm username_length, 8
@@ -18,13 +19,26 @@ env_session:    .ascii "XDG_SESSION_TYPE"
 .lcomm target, 65
 
 parse_envs:
-	mov  rsi, 4
+	mov  rsi, 8
 	mov  rdx, offset env_username
 	mov  rdi, offset username
 	call find_env_var
 	mov  username_length, rcx
+
+	test rcx, rcx
+	jz username_found_first_try
 	xor  rcx, rcx
 
+	mov  rsi, 4
+	mov  rdx, offset env_username_alt
+	mov  rdi, offset username
+	call find_env_var
+	mov  username_length, rcx
+	xor  rcx, rcx
+	jmp continue
+	
+username_found_first_try:
+	xor  rcx, rcx
 	mov  rsi, 5
 	mov  rdx, offset env_shell
 	mov  rdi, offset shell_path
@@ -32,6 +46,7 @@ parse_envs:
 	mov  shell_path_length, rcx
 	xor  rcx, rcx
 
+continue:
 	mov  rsi, 19
 	mov  rdx, offset env_desktop
 	mov  rdi, offset desktop

--- a/env.S
+++ b/env.S
@@ -35,7 +35,6 @@ parse_envs:
 	call find_env_var
 	mov  username_length, rcx
 	xor  rcx, rcx
-	jmp continue
 	
 username_found_first_try:
 	xor  rcx, rcx
@@ -88,6 +87,7 @@ env_char_matched:
 	mov  rsi, rax
 	add  rsi, r9
 	inc  rsi
+	xor r15, r15 # ensure r15 is zero
 	call copy
 
 find_env_var_done:

--- a/env.S
+++ b/env.S
@@ -26,7 +26,7 @@ parse_envs:
 	mov  username_length, rcx
 
 	test rcx, rcx
-	jz username_found_first_try
+	jnz username_found_first_try
 	xor  rcx, rcx
 
 	mov  rsi, 4

--- a/print.S
+++ b/print.S
@@ -1,11 +1,11 @@
 .lcomm print_buf, 1024
 
 print:
-	mov bl, [rsi]
-	inc rsi
+	mov bl, [rsi] # Copying over array
+	inc rsi # Increment pointer
 
-	mov [print_buf + r10], bl
-	inc r10
+	mov [print_buf + r10], bl # Copy to offset
+	inc r10 # increment length
 
 	dec rcx
 	jnz print
@@ -34,5 +34,5 @@ flush:
 	mov rdx, r10
 	syscall
 
-	xor r10, r10
+	mov r10, 0x0 # Unsure why we would use XOR here, except if xor is more performant than mov
 	ret

--- a/print.S
+++ b/print.S
@@ -34,5 +34,5 @@ flush:
 	mov rdx, r10
 	syscall
 
-	mov r10, 0x0 # Unsure why we would use XOR here, except if xor is more performant than mov
+	xor r10, r10
 	ret


### PR DESCRIPTION
Because of a hardcoded env-variable offset in $rsp environment variable injectiosn was possibel through argv. I fixed this by using argc, also I fixed a bug concerning the username env variable where systems using the variable "USERNAME" would get half the variable in their username output because the program is hardcoded to use "USER". Fixed this and made it compatible for both setups.

Please review @ErrorNoInternet, it should work but USER may be broken, unsure!