### PR TITLE
chore: add Makefile and update README.md accordingly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ asmfetch: asmfetch.S
 	@sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
 	gcc -nostdlib -no-pie -x assembler - -o $@
 
-install:
 	#TODO make this work on systems without sudo
 	@install -Dm755 asmfetch /usr/local/bin/
+install: asmfetch
 
 
 .PHONY: all install

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ install:
 	@install -Dm755 asmfetch /usr/local/bin/
 
 
-.PHONY: compile_with_distro_logo install
+.PHONY: all install

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-DISTRO_ID := $(shell sed -n '/^ID=/ s/ID=//p' /etc/os-release)
+DISTRO_ID := $(shell sed -n 's/^ID=//p' /etc/os-release)
 
 asmfetch: asmfetch.S
 	sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
 	gcc -nostdlib -no-pie -x assembler - -o $@
 
 install: asmfetch
-	install -Dm755 asmfetch /usr/local/bin/
+	install -Dm755 asmfetch /usr/local/bin/asmfetch
 
+clean:
+	rm -f asmfetch
 
-.PHONY: install
+.PHONY: install clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 DISTRO_ID := $(shell sed -n '/^ID=/ s/ID=//p' /etc/os-release)
 
-all: asmfetch
-
 asmfetch: asmfetch.S
 	sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
 	gcc -nostdlib -no-pie -x assembler - -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+DISTRO_ID := $(shell sed -n '/^ID=/ s/ID=//p' /etc/os-release)
+
+all: compile_with_distro_logo
+
+compile_with_distro_logo:
+	sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
+	gcc -nostdlib -no-pie -x assembler - -o asmfetch
+
+install:
+	#TODO make this work on systems without sudo
+	sudo cp asmfetch /usr/local/bin/asmfetch
+
+
+.PHONY: compile_with_distro_logo install

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 DISTRO_ID := $(shell sed -n '/^ID=/ s/ID=//p' /etc/os-release)
 
-all: compile_with_distro_logo
+all: asmfetch
 
-compile_with_distro_logo:
-	sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
-	gcc -nostdlib -no-pie -x assembler - -o asmfetch
+asmfetch: asmfetch.S
+	@sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
+	gcc -nostdlib -no-pie -x assembler - -o $@
 
 install:
 	#TODO make this work on systems without sudo

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,11 @@ DISTRO_ID := $(shell sed -n '/^ID=/ s/ID=//p' /etc/os-release)
 all: asmfetch
 
 asmfetch: asmfetch.S
-	@sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
+	sed -E 's|(\.include "logo/).*(\.S")|\1'"${DISTRO_ID}"'\2|' asmfetch.S |\
 	gcc -nostdlib -no-pie -x assembler - -o $@
 
-	#TODO make this work on systems without sudo
-	@install -Dm755 asmfetch /usr/local/bin/
 install: asmfetch
+	install -Dm755 asmfetch /usr/local/bin/
 
 
 .PHONY: all install

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ install: asmfetch
 	install -Dm755 asmfetch /usr/local/bin/
 
 
-.PHONY: all install
+.PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ compile_with_distro_logo:
 
 install:
 	#TODO make this work on systems without sudo
-	sudo cp asmfetch /usr/local/bin/asmfetch
+	cp asmfetch /usr/local/bin/asmfetch
 
 
 .PHONY: compile_with_distro_logo install

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ asmfetch: asmfetch.S
 
 install:
 	#TODO make this work on systems without sudo
-	cp asmfetch /usr/local/bin/asmfetch
+	@install -Dm755 asmfetch /usr/local/bin/
 
 
 .PHONY: compile_with_distro_logo install

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Runs in under 150 microseconds and has zero dependencies.
 - hostname
 - os name from `/etc/os-release`
 - kernel
-  - name
-  - version
-  - architecture
+    - name
+    - version
+    - architecture
 - shell (`$SHELL`)
 - uptime
 - desktop (`$XDG_CURRENT_DESKTOP`)
@@ -24,8 +24,8 @@ Runs in under 150 microseconds and has zero dependencies.
 ## Usage
 
 ```sh
-make # replaces fedora logo with your distro's and compiles
-sudo make install # copies asmfetch to /usr/local/bin
+make
+sudo make install
 asmfetch
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Runs in under 150 microseconds and has zero dependencies.
 - hostname
 - os name from `/etc/os-release`
 - kernel
-    - name
-    - version
-    - architecture
+  - name
+  - version
+  - architecture
 - shell (`$SHELL`)
 - uptime
 - desktop (`$XDG_CURRENT_DESKTOP`)
@@ -23,9 +23,10 @@ Runs in under 150 microseconds and has zero dependencies.
 
 ## Usage
 
-```shell
-$ gcc -nostdlib -no-pie asmfetch.S -o asmfetch
-$ ./asmfetch
+```sh
+make # replaces fedora logo with your distro's and compiles
+make install # copies asmfetch to /usr/local/bin
+asmfetch
 ```
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Runs in under 150 microseconds and has zero dependencies.
 
 ```sh
 make # replaces fedora logo with your distro's and compiles
-make install # copies asmfetch to /usr/local/bin
+sudo make install # copies asmfetch to /usr/local/bin
 asmfetch
 ```
 


### PR DESCRIPTION
Add Makefile that eases compilation and install.

Automatically get distro ID from `/etc/os-release` and `sed` line in asmfetch.S to change distro logo include, then pipe resulting text into gcc without modifying the original file.

Also added install target for easy installation.